### PR TITLE
Always enclose string in quotes

### DIFF
--- a/dds-xrce-idl.lua
+++ b/dds-xrce-idl.lua
@@ -177,7 +177,7 @@ function string_deserialize(tvb, offset, encoding, tree, label)
 
     local size = tvb_uint(tvb(offset, 4), encoding)
     offset = offset + 4
-    tree:add(tvb(offset, size), label, tvb(offset, size):stringz())
+    tree:add(tvb(offset, size), label, string.format("\"%s\"", tvb(offset, size):stringz()))
     offset = offset + size
 
     return offset


### PR DESCRIPTION
As per subject.

A change I've had locally for some time now and thought I'd share.

I have quite some messages with empty strings, which, without quotes, looks rather odd:

```
my_field:
```

with this change, that'd become:

```
my_field: ''
```

Personally I like the fact it always quotes strings (ie: also when they're non-empty), but perhaps you don't. Could make it conditional, but that seems like a lot of overhead.
